### PR TITLE
fixes parallel test cmake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,14 +39,14 @@ macro(add_unit_test)
                             ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
     endif(HAVE_MPI)
 
-    if(TEST_PARALLEL AND HAVE_MPI)
+    if(PARALLEL AND HAVE_MPI)
       set(TESTCOMMAND ${MPIEXEC})
       set(TESTARGS ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
                    "./${TEST_NAME}" ${MPIEXEC_POSTFLAGS})
       set(TESTCOMMAND ${TESTCOMMAND} ${TESTARGS})
-    else(TEST_PARALLEL AND HAVE_MPI)
+    else()
       set(TESTCOMMAND ${TEST_NAME})
-    endif(TEST_PARALLEL AND HAVE_MPI)
+    endif()
     add_test(NAME ${TEST_NAME}
              WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/rundir/test
              COMMAND ${TESTCOMMAND})


### PR DESCRIPTION
## Description of the new code

Fixes tests CMakeList parallel execution. It seems there was a typo n the parallel variable name. This is (ironically) untested.

I saw this while reading your [article about testing](https://bertvandenbroucke.netlify.app/2019/12/12/unit-testing-with-ctest/) and I thought I could help.

It is very possible that I'm completely wrong, in that case, sorry for wasting your time.

## Impact of the new code

Tests are able to run in parallel and use MPI
