### PR TITLE
ignore \0 characters in help output

### DIFF
--- a/src/CommandLineOption.cpp
+++ b/src/CommandLineOption.cpp
@@ -136,7 +136,11 @@ void CommandLineOption::print_usage(std::ostream &stream) const {
  */
 void CommandLineOption::print_description(std::ostream &stream) const {
 
-  stream << "--" << _name << " (-" << _abbreviation << ")\n";
+  if (_abbreviation == 0) {
+    stream << "--" << _name << " (-)\n";
+  } else {
+    stream << "--" << _name << " (-" << _abbreviation << ")\n";
+  }
   stream << _description << "\n";
   stream << get_argument_description(_argument);
   std::string default_value_description =


### PR DESCRIPTION
## Description of the new code

\00 characters included in the command line output of the `print_description` function (when there is no abbreviation for a command line option) resulted in encoding errors when saving stdout and stderr to text files using python.

## Impact of the new code

When `_abbreviation` is '\00', don't include it in the `ostream`. 
